### PR TITLE
fix: ensure to fire reactions after onEnter/onParamsChange is called

### DIFF
--- a/src/router-store.ts
+++ b/src/router-store.ts
@@ -77,31 +77,31 @@ export class RouterStore<S extends Store> {
             );
 
         runInAction(() => {
+            const nextParams = toJS(paramsObj) as P
+            const nextQueryParams = toJS(queryParamsObj) as Q;
+            
             this.currentRoute = route;
-            this.params = toJS(paramsObj) as P;
-            this.queryParams = toJS(queryParamsObj) as Q;
+            this.params = nextParams;
+            this.queryParams = nextQueryParams;
+
+            routeChanged &&
+                route.onEnter &&
+                route.onEnter(route,
+                    nextParams,
+                    this.store,
+                    nextQueryParams,
+                );
+    
+            !routeChanged &&
+                this.currentRoute &&
+                this.currentRoute.onParamsChange &&
+                this.currentRoute.onParamsChange(
+                    this.currentRoute,
+                    nextParams,
+                    this.store,
+                    nextQueryParams
+                );
         });
-
-        const nextParams = toJS(this.params as P);
-        const nextQueryParams = toJS(this.queryParams as Q);
-
-        routeChanged &&
-            route.onEnter &&
-            route.onEnter(route,
-                nextParams,
-                this.store,
-                nextQueryParams,
-            );
-
-        !routeChanged &&
-            this.currentRoute &&
-            this.currentRoute.onParamsChange &&
-            this.currentRoute.onParamsChange(
-                this.currentRoute,
-                nextParams,
-                this.store,
-                nextQueryParams
-            );
     }
 
     @computed


### PR DESCRIPTION
We put some code in `onEnter/onParamsChange` that needs to be executed prior to the UI components on the route being rendered. However, MobX router (probably unintentionally) triggers rendering those UI components that observe `router.currentPath/params/queryParams` before these callbacks are called. This fix is to ensure `onEnter/onParamsChange` is called before the reactions are triggered when `router.currentPath/params/queryParams` is changed, by moving the callback invocation within the same `runInAction`.